### PR TITLE
Bump version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evm-bridge-frontend",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
We decided that latest fixes belongs to 0.9.1. 
So we should bump the version.